### PR TITLE
Correción de la variable cp por postalCode

### DIFF
--- a/frontend/src/app/components/address-input/address-input.component.html
+++ b/frontend/src/app/components/address-input/address-input.component.html
@@ -1,6 +1,6 @@
 <div class="input-container">
   <input class="postal" type="text" 
-    [(ngModel)]="cp" 
+    [(ngModel)]="postalCode" 
     (ngModelChange)="postalChange.emit($event)" 
     placeholder="C.P.">
   <input type="text" 


### PR DESCRIPTION
## Descripción
Cambié el nombre de la variable cp por postalCode en todo el codigo pero una se coló, produciendo un error. Esto lo corrige.

## Checklist antes de enviar PR

- [ ] Código compila y pasa todos los tests en local.
- [ ] He pasado el linter/formatter.
- [ ] No hay archivos innecesarios añadidos (logs, temporales, etc.).
- [ ] Mensaje de commit claro (`feat:`, `fix:`, etc.).
- [ ] He probado los cambios en mi entorno local.
- [ ] La documentación está actualizada si aplica.

